### PR TITLE
added a fallback for pim5 constant use

### DIFF
--- a/Command/LoadFixturesCommand.php
+++ b/Command/LoadFixturesCommand.php
@@ -47,7 +47,7 @@ class LoadFixturesCommand extends AbstractCommand
 
             $fixtureLoader = new FixtureLoader($checkPathExists, $omitValidation);
             foreach ($fixtureFiles as $fixtureFile) {
-                $progress->setMessage('<comment>Loading</comment>  ' . str_replace(PIMCORE_WEBSITE_VAR, '', $fixtureFile));
+                $progress->setMessage('<comment>Loading</comment>  ' . str_replace(defined('PIMCORE_PRIVATE_VAR') ? PIMCORE_PRIVATE_VAR : PIMCORE_WEBSITE_VAR, '', $fixtureFile));
                 $progress->advance();
                 $fixtureLoader->load($fixtureFile);
             }


### PR DESCRIPTION
if pim5 pimcore_private_var constant is available use it, otherwise rely on pim4, pimcore_website_var